### PR TITLE
Handle dynamic text overflow in container

### DIFF
--- a/landing/styles.css
+++ b/landing/styles.css
@@ -210,8 +210,8 @@ body {
   padding: 16px;
   box-shadow: 0 16px 60px rgba(2, 8, 23, 0.6);
 }
-.editor-line { background: rgba(3, 8, 23, 0.66); border: 1px solid rgba(255,255,255,0.06); padding: 10px 12px; border-radius: 10px; margin: 10px 0; }
-.token { color: var(--accent); font-weight: 700; margin-right: 6px; }
+.editor-line { display: flex; align-items: center; gap: 8px; background: rgba(3, 8, 23, 0.66); border: 1px solid rgba(255,255,255,0.06); padding: 10px 12px; border-radius: 10px; margin: 10px 0; }
+.token { color: var(--accent); font-weight: 700; }
 .token.ok { color: var(--ok); }
 .token.warn { color: var(--warning); }
 
@@ -377,3 +377,4 @@ body {
     padding: 14px 0;
   }
 }
+.editor-line .typing { flex: 1 1 auto; min-width: 0; max-width: 100%; overflow: hidden; text-overflow: ellipsis; }


### PR DESCRIPTION
Implement text truncation for dynamic content to prevent overflow in `.editor-line`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce378025-346a-4fe2-abcf-9ea34a241309">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ce378025-346a-4fe2-abcf-9ea34a241309">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

