### PR TITLE
Show loader for missing subscriber counts

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -109,7 +109,9 @@
                 <p class="beta-note">
                   <span class="countdown">⏳ <strong>Béta indul: október 22.</strong></span>
                   <span class="scarcity">🔥 <strong>Már csak <span id="remaining-spots">...</span> hely van!</strong></span>
-                  <span class="waitlist-info" id="waitlist-counter">... vállalkozó már biztosította a helyét</span>
+                  <span class="waitlist-info" id="waitlist-counter" aria-live="polite">
+                    <span class="inline-loader"><span class="inline-spinner" aria-hidden="true"></span><span>Betöltés...</span></span>
+                  </span>
                 </p>
               </div>
             </div>
@@ -314,7 +316,7 @@
             </form>
           </div>
           <p class="disclaimer">Csak indításkor írunk. Nincs spam.</p>
-          <p class="beta-note"><strong>Béta indul: október 22.</strong> 50 hely. <span id="waitlist-counter-2">Már 0 feliratkozó a várólistán</span>.</p>
+          <p class="beta-note"><strong>Béta indul: október 22.</strong> 50 hely. <span id="waitlist-counter-2" aria-live="polite"><span class="inline-loader"><span class="inline-spinner" aria-hidden="true"></span><span>Betöltés...</span></span></span>.</p>
         </div>
       </section>
 

--- a/landing/script.js
+++ b/landing/script.js
@@ -40,9 +40,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const formatCounterText = (count) => `${count} vállalkozó már biztosította a helyét`;
   
-  let currentCount = 30; // Kezdő érték az AIDA szöveghez illeszkedően
+  let currentCount = null; // Betöltés alatt – amíg nincs adat, loader marad
 
   const renderCounter = () => {
+    if (!Number.isFinite(currentCount)) return; // amíg nincs szám, ne írjuk felül a loadert
     counterEls.forEach(el => {
       el.textContent = formatCounterText(currentCount);
     });
@@ -53,8 +54,6 @@ document.addEventListener('DOMContentLoaded', () => {
       remainingSpotsEl.textContent = remaining;
     }
   };
-
-  renderCounter();
   
   // Valós szám lekérése és periódikus frissítése
   const updateCounterFromRemote = async () => {

--- a/landing/styles.css
+++ b/landing/styles.css
@@ -929,6 +929,25 @@ body {
   .hero-visual { order: -1; }
 }
 
+/* Inline loader */
+.inline-loader {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted);
+}
+.inline-spinner {
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: inline-spin 0.8s linear infinite;
+}
+@keyframes inline-spin {
+  to { transform: rotate(360deg); }
+}
+
 @media (max-width: 720px) {
   .container {
     width: 92vw;


### PR DESCRIPTION
Display a loader for subscriber counts until data is fetched to improve user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-497b84d0-1b57-4c4c-8834-2df06562f13b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-497b84d0-1b57-4c4c-8834-2df06562f13b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show an inline loader and use aria-live while deferring waitlist counter rendering until subscriber data is fetched; add corresponding CSS.
> 
> - **Landing page**
>   - **HTML**: Wrap `#waitlist-counter` and `#waitlist-counter-2` in `aria-live="polite"` containers and insert inline loader markup.
>   - **JS (`landing/script.js`)**:
>     - Initialize `currentCount = null` and guard `renderCounter` to skip until a valid number.
>     - Remove initial `renderCounter()` call so loaders remain until remote data arrives.
>   - **CSS (`landing/styles.css`)**: Add `.inline-loader`, `.inline-spinner`, and `@keyframes inline-spin` for the inline loading indicator.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c7a2f3956459fb6ff1c8a2469d7d115814b6f2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->